### PR TITLE
Fix deprecated include directive.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: preflight.yml
+- include_tasks: preflight.yml
 
 # Create mercure user and group
 - name: create "{{ mercure_rocks_user }}" group


### PR DESCRIPTION
Role cannot be used with recent enough Ansible versions due to `ansible.builtin.include` being removed from ansible-core after 2023-05-16.
Updated `include` to `include_tasks`, now everything works properly.